### PR TITLE
Corrige habilitação do campo recursos para provas quando aluno possui deficiência

### DIFF
--- a/ieducar/modules/Api/Views/AlunoController.php
+++ b/ieducar/modules/Api/Views/AlunoController.php
@@ -2291,7 +2291,7 @@ protected function possiveisDuplicatas()
             ->getKeyValueArray('transtorno_educacenso');
 
         $arrayEducacensoDeficiencies = [];
-        foreach ($deficiencias as $deficiency) {
+        foreach ($deficiencies as $deficiency) {
             $deficiencyObject = LegacyDeficiency::find($deficiency);
 
             if (!$deficiencyObject) {
@@ -2300,13 +2300,9 @@ protected function possiveisDuplicatas()
 
             if ($deficiencyObject->deficiency_type_id == DeficiencyType::DEFICIENCY) {
                 $arrayEducacensoDeficiencies[] = $databaseDeficiencies[$deficiency];
-            }
-
-            if ($deficiencyObject->deficiency_type_id == DeficiencyType::DISORDER) {
+            } elseif ($deficiencyObject->deficiency_type_id == DeficiencyType::DISORDER) {
                 $arrayEducacensoDeficiencies[] = $databaseDisorders[$deficiency];
             }
-
-            $arrayEducacensoDeficiencies[] = $databaseDeficiencies[$deficiency];
         }
 
         return $arrayEducacensoDeficiencies;

--- a/public/vendor/legacy/Cadastro/Assets/Javascripts/Aluno.js
+++ b/public/vendor/legacy/Cadastro/Assets/Javascripts/Aluno.js
@@ -1088,6 +1088,39 @@ let verificaCampoZonaResidencia = () => {
 
 $j("#pais_residencia").change(verificaCampoZonaResidencia);
 
+function habilitaRecursosProvaInep() {
+  var deficiencias = $j("#deficiencias").val() || [];
+  var transtornos = $j("#transtornos").val() || [];
+  var combinados = deficiencias.concat(transtornos);
+
+  var additionalVars = {
+    deficiencias: combinados,
+  };
+
+  var options = {
+    url: getResourceUrlBuilder.buildUrl(
+      "/module/Api/aluno",
+      "deve-habilitar-campo-recursos-prova-inep",
+      additionalVars
+    ),
+    dataType: "json",
+    data: {},
+    success: function (response) {
+      if (response.result) {
+        $j("#recursos_prova_inep__")
+          .prop("disabled", false)
+          .trigger("chosen:updated");
+      } else {
+        $j("#recursos_prova_inep__")
+          .prop("disabled", true)
+          .val([])
+          .trigger("chosen:updated");
+      }
+    },
+  };
+  getResource(options);
+}
+
 var handleGetPersonDetails = function (dataResponse) {
   handleMessages(dataResponse.msgs);
   $pessoaNotice.hide();
@@ -1206,43 +1239,7 @@ var handleGetPersonDetails = function (dataResponse) {
   $deficiencias.trigger("chosen:updated");
   $transtornos.trigger("chosen:updated");
 
-  function habilitaRecursosProvaInep() {
-    var deficiencias = $j("#deficiencias").val();
-    var transtornos = $j("#transtornos").val();
-
-    var combinados = deficiencias.concat(transtornos);
-
-    var additionalVars = {
-      deficiencias: combinados,
-    };
-
-    var options = {
-      url: getResourceUrlBuilder.buildUrl(
-        "/module/Api/aluno",
-        "deve-habilitar-campo-recursos-prova-inep",
-        additionalVars
-      ),
-      dataType: "json",
-      data: {},
-      success: function (response) {
-        if (response.result) {
-          $j("#recursos_prova_inep__")
-            .prop("disabled", false)
-            .trigger("chosen:updated");
-        } else {
-          $j("#recursos_prova_inep__")
-            .prop("disabled", true)
-            .val([])
-            .trigger("chosen:updated");
-        }
-      },
-    };
-    getResource(options);
-  }
-
   habilitaRecursosProvaInep();
-
-  $j("#deficiencias").on("change", habilitaRecursosProvaInep);
 
   $j("#tipo_responsavel").find("option").remove().end();
 
@@ -1613,6 +1610,11 @@ function canShowParentsFields() {
     $j("#documento").on("change", prepareUploadDocumento);
 
     $j("#deficiencias").trigger("chosen:updated");
+
+    $j("#recursos_prova_inep__")
+      .prop("disabled", true)
+      .trigger("chosen:updated");
+    $j("#deficiencias, #transtornos").on("change", habilitaRecursosProvaInep);
 
     function prepareUpload(event) {
       $j("#laudo_medico").removeClass("error");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**DESCRIÇÃO:**

O campo "Recursos necessários para realização de provas" permanecia inativo (exibindo "Selecione as opções") mesmo quando o aluno possuía deficiência ou transtorno cadastrado.

A causa principal era um typo introduzido recentemente em `replaceByEducacensoDeficiencies`, que iterava sobre a variável inexistente `$deficiencias` em vez de `$deficiencies`, fazendo com que a API `deve-habilitar-campo-recursos-prova-inep` sempre retornasse `result: false`.

Alterações:
- Corrige o typo no loop de mapeamento de deficiências/transtornos do Educacenso
- Remove a adição duplicada de valores no mapeamento
- Registra listener de `change` também para o campo de transtornos
- Inicializa o campo como desabilitado e trata valores nulos no JavaScript

**AMBIENTE:**

- Cloud Agent (Linux)
- Branch base: `2.11`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9abee32-18d7-437e-bddf-3553c0e21e39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9abee32-18d7-437e-bddf-3553c0e21e39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

