### PR TITLE
Corrige erro getOptions() em configuracoes gerais do boletim do professor

### DIFF
--- a/ieducar/intranet/educar_configuracoes_gerais.php
+++ b/ieducar/intranet/educar_configuracoes_gerais.php
@@ -182,10 +182,23 @@ return new class extends clsCadastro
             'value' => $this->tamanho_min_rede_estadual,
         ]);
 
-        $teacherReporcCard = app(TeacherReportCard::class);
+        $defaultReportOptions = [
+            1 => 'Modelo padrão',
+            2 => 'Recuperação paralela',
+            3 => 'Recuperação por etapa',
+        ];
+        try {
+            $teacherReportCard = app(TeacherReportCard::class);
+            $reportOptions = (is_object($teacherReportCard) && method_exists($teacherReportCard, 'getOptions'))
+                ? $teacherReportCard->getOptions()
+                : $defaultReportOptions;
+        } catch (Throwable $e) {
+            $reportOptions = $defaultReportOptions;
+        }
+        $reportOptions = $reportOptions ?? $defaultReportOptions;
         $options = [
             'label' => 'Modelo do boletim do professor',
-            'resources' => $teacherReporcCard->getOptions(),
+            'resources' => $reportOptions,
             'value' => $this->modelo_boletim_professor,
         ];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

Ao acessar `/intranet/educar_configuracoes_gerais.php`, a aplicação lançava:

```
Call to undefined method TeacherReportCardReport::getOptions()
```

A tela chamava `getOptions()` diretamente na implementação do contrato `TeacherReportCard`, mas a classe `TeacherReportCardReport` do módulo Reports não expõe esse método.

## Causa

O commit `5d8cb00f1` (atualizações de layout e configurações) reverteu acidentalmente o tratamento defensivo adicionado anteriormente em `4fce39f3f`.

## Solução

Restaura a lógica que:

1. Tenta obter as opções via `getOptions()` quando o método existir.
2. Usa opções padrão como fallback quando o método não estiver disponível ou ocorrer erro.

## Opções padrão

- Modelo padrão
- Recuperação paralela
- Recuperação por etapa

## Arquivo alterado

- `ieducar/intranet/educar_configuracoes_gerais.php`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20c53af9-521d-4cc9-b1e9-78c5b205f7d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20c53af9-521d-4cc9-b1e9-78c5b205f7d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

