### PR TITLE
Corrige carregamento de relatórios na Documentação padrão

### DIFF
--- a/app/Models/LegacyInstitutionDocument.php
+++ b/app/Models/LegacyInstitutionDocument.php
@@ -16,5 +16,6 @@ class LegacyInstitutionDocument extends Model
         'url_documento',
         'ref_usuario_cad',
         'ref_cod_escola',
+        'ano',
     ];
 }

--- a/database/migrations/table/2026_06_26_120000_add_ano_in_pmieducar_instituicao_documentacao.php
+++ b/database/migrations/table/2026_06_26_120000_add_ano_in_pmieducar_instituicao_documentacao.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        if (!Schema::hasColumn('pmieducar.instituicao_documentacao', 'ano')) {
+            Schema::table('pmieducar.instituicao_documentacao', function (Blueprint $table) {
+                $table->integer('ano')->default((int) date('Y'));
+            });
+        }
+    }
+
+    public function down()
+    {
+        if (Schema::hasColumn('pmieducar.instituicao_documentacao', 'ano')) {
+            Schema::table('pmieducar.instituicao_documentacao', function (Blueprint $table) {
+                $table->dropColumn('ano');
+            });
+        }
+    }
+};

--- a/ieducar/intranet/DocumentacaoPadrao.php
+++ b/ieducar/intranet/DocumentacaoPadrao.php
@@ -50,6 +50,8 @@ return new class extends clsCadastro
                 $this->nm_instituicao = $det_instituicao['nm_instituicao'];
                 $this->campoRotulo('nm_instituicao', 'Institução', $this->nm_instituicao);
             }
+        } else {
+            $this->inputsHelper()->dynamic(['instituicao']);
         }
 
         $this->largura = '100%';
@@ -57,8 +59,6 @@ return new class extends clsCadastro
         $this->breadcrumb('Documentação padrão', [
             url('intranet/educar_index.php') => 'Escola',
         ]);
-
-        $this->inputsHelper()->dynamic(['instituicao']);
 
         $opcoes_relatorio = [];
         $opcoes_relatorio[''] = 'Selecione';

--- a/ieducar/intranet/DocumentacaoPadrao.php
+++ b/ieducar/intranet/DocumentacaoPadrao.php
@@ -60,6 +60,10 @@ return new class extends clsCadastro
             url('intranet/educar_index.php') => 'Escola',
         ]);
 
+        $opcoes_ano = [];
+        $opcoes_ano[''] = 'Selecione';
+        $this->campoLista('ano', 'Ano', $opcoes_ano);
+
         $opcoes_relatorio = [];
         $opcoes_relatorio[''] = 'Selecione';
         $this->campoLista('relatorio', 'Relatório', $opcoes_relatorio);

--- a/ieducar/intranet/educar_documentacao_instituicao_cad.php
+++ b/ieducar/intranet/educar_documentacao_instituicao_cad.php
@@ -31,6 +31,15 @@ return new class extends clsCadastro
         $this->campoOculto(nome: 'pessoa_logada', valor: $this->pessoa_logada);
         $this->campoOculto(nome: 'ref_cod_escola', valor: $this->ref_cod_escola);
 
+        $this->campoNumero(
+            nome: 'ano',
+            campo: 'Ano',
+            valor: date('Y'),
+            tamanhovisivel: 4,
+            tamanhomaximo: 4,
+            obrigatorio: true
+        );
+
         $this->campoTexto(nome: 'titulo_documento', campo: 'Título', valor: $this->titulo_documento, tamanhovisivel: 30, tamanhomaximo: 50);
 
         $this->campoArquivo(nome: 'documento', campo: 'Documentação padrão', valor: $this->documento, tamanho: 40, descricao: '<span id=\'aviso_formato\'>São aceitos apenas arquivos no formato PDF com até 2MB.</span>');

--- a/ieducar/intranet/scripts/extra/DocumentacaoPadrao.js
+++ b/ieducar/intranet/scripts/extra/DocumentacaoPadrao.js
@@ -1,7 +1,59 @@
-var instituicaoId = document.getElementById('ref_cod_instituicao').value;
-if (instituicaoId != '') {
+var searchPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=getDocuments';
+
+function setRelatorioLoadingState() {
   var selectRelatorio = document.getElementById('relatorio');
   selectRelatorio.length = 1;
+  selectRelatorio.disabled = true;
+  selectRelatorio.options[0].text = 'Carregando relatórios';
+}
+
+function resetRelatorioSelect(message) {
+  var selectRelatorio = document.getElementById('relatorio');
+  selectRelatorio.length = 1;
+  selectRelatorio.options[0].text = message;
+  selectRelatorio.disabled = false;
+}
+
+function populateRelatorioSelect(documentos) {
+  var selectRelatorio = document.getElementById('relatorio');
+  selectRelatorio.length = 1;
+
+  if (!documentos || !documentos.length) {
+    resetRelatorioSelect('A instituição não possui relatórios cadastrados');
+    return;
+  }
+
+  selectRelatorio.options[0].text = 'Selecione um relatório';
+  selectRelatorio.disabled = false;
+
+  for (var i = 0; i < documentos.length; i++) {
+    var option = document.createElement('option');
+    option.text = documentos[i].titulo_documento;
+    option.value = documentos[i].url_documento;
+    selectRelatorio.add(option);
+  }
+}
+
+function getDocumento(instituicaoId) {
+  var params = { instituicao_id: instituicaoId };
+
+  $j.get(searchPath, params)
+    .done(function (data) {
+      if (data && data.any_error_msg) {
+        resetRelatorioSelect('Não foi possível carregar os relatórios');
+        return;
+      }
+
+      populateRelatorioSelect(data ? data.documentos : []);
+    })
+    .fail(function () {
+      resetRelatorioSelect('Não foi possível carregar os relatórios');
+    });
+}
+
+var instituicaoId = document.getElementById('ref_cod_instituicao').value;
+if (instituicaoId != '') {
+  setRelatorioLoadingState();
   getDocumento(instituicaoId);
 }
 
@@ -9,15 +61,12 @@ document.getElementById('btn_enviar').style.display = 'none';
 
 document.getElementById('ref_cod_instituicao').onchange = function () {
   var selectRelatorio = document.getElementById('relatorio');
+
   if (this.selectedIndex !== 0) {
-    selectRelatorio.length = 1;
-    selectRelatorio.disabled = true;
-    selectRelatorio.options[0].text = 'Carregando Relatorios';
-    var instituicaoId = document.getElementById('ref_cod_instituicao').value;
-    getDocumento(instituicaoId);
+    setRelatorioLoadingState();
+    getDocumento(document.getElementById('ref_cod_instituicao').value);
   } else {
-    selectRelatorio.length = 1;
-    selectRelatorio.options[0].text = 'Selecione';
+    resetRelatorioSelect('Selecione');
   }
 };
 
@@ -26,26 +75,3 @@ document.getElementById('relatorio').onchange = function () {
     window.open(linkUrlPrivada(this.value), '_blank');
   }
 };
-
-function getDocumento(instituicaoId) {
-  var searchPath = '../module/Api/InstituicaoDocumentacao?oper=get&resource=getDocuments';
-  var params = { instituicao_id: instituicaoId };
-  var id = '';
-  var titulo = '';
-  var url = '';
-
-  $j.get(searchPath, params, function (data) {
-
-    var documentos = data.documentos;
-
-    for (var i = 0; i < documentos.length; i++) {
-      var selectRelatorio = document.getElementById('relatorio');
-      var option = document.createElement('option');
-      selectRelatorio.options[0].text = 'Selecione um relatório';
-      selectRelatorio.disabled = false;
-      option.text = documentos[i].titulo_documento;
-      option.value = documentos[i].url_documento;
-      selectRelatorio.add(option);
-    }
-  });
-}

--- a/ieducar/intranet/scripts/extra/DocumentacaoPadrao.js
+++ b/ieducar/intranet/scripts/extra/DocumentacaoPadrao.js
@@ -1,17 +1,53 @@
 var searchPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=getDocuments';
+var yearsPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=getYears';
+
+function setSelectLoadingState(selectId, message) {
+  var select = document.getElementById(selectId);
+  select.length = 1;
+  select.disabled = true;
+  select.options[0].text = message;
+}
+
+function resetSelect(selectId, message, disabled) {
+  var select = document.getElementById(selectId);
+  select.length = 1;
+  select.options[0].text = message;
+  select.disabled = disabled;
+}
 
 function setRelatorioLoadingState() {
-  var selectRelatorio = document.getElementById('relatorio');
-  selectRelatorio.length = 1;
-  selectRelatorio.disabled = true;
-  selectRelatorio.options[0].text = 'Carregando relatórios';
+  setSelectLoadingState('relatorio', 'Carregando relatórios');
 }
 
 function resetRelatorioSelect(message) {
-  var selectRelatorio = document.getElementById('relatorio');
-  selectRelatorio.length = 1;
-  selectRelatorio.options[0].text = message;
-  selectRelatorio.disabled = false;
+  resetSelect('relatorio', message, false);
+}
+
+function resetAnoSelect(message) {
+  resetSelect('ano', message, false);
+}
+
+function populateAnoSelect(anos) {
+  var selectAno = document.getElementById('ano');
+  selectAno.length = 1;
+
+  if (!anos || !anos.length) {
+    resetAnoSelect('A instituição não possui documentos cadastrados');
+    resetRelatorioSelect('Selecione');
+    return;
+  }
+
+  selectAno.options[0].text = 'Selecione um ano';
+  selectAno.disabled = false;
+
+  for (var i = 0; i < anos.length; i++) {
+    var option = document.createElement('option');
+    option.text = anos[i];
+    option.value = anos[i];
+    selectAno.add(option);
+  }
+
+  resetRelatorioSelect('Selecione');
 }
 
 function populateRelatorioSelect(documentos) {
@@ -19,7 +55,7 @@ function populateRelatorioSelect(documentos) {
   selectRelatorio.length = 1;
 
   if (!documentos || !documentos.length) {
-    resetRelatorioSelect('A instituição não possui relatórios cadastrados');
+    resetRelatorioSelect('Não há relatórios para o ano selecionado');
     return;
   }
 
@@ -34,8 +70,27 @@ function populateRelatorioSelect(documentos) {
   }
 }
 
-function getDocumento(instituicaoId) {
+function getAnos(instituicaoId) {
   var params = { instituicao_id: instituicaoId };
+
+  $j.get(yearsPath, params)
+    .done(function (data) {
+      if (data && data.any_error_msg) {
+        resetAnoSelect('Não foi possível carregar os anos');
+        resetRelatorioSelect('Selecione');
+        return;
+      }
+
+      populateAnoSelect(data ? data.anos : []);
+    })
+    .fail(function () {
+      resetAnoSelect('Não foi possível carregar os anos');
+      resetRelatorioSelect('Selecione');
+    });
+}
+
+function getDocumento(instituicaoId, ano) {
+  var params = { instituicao_id: instituicaoId, ano: ano };
 
   $j.get(searchPath, params)
     .done(function (data) {
@@ -51,22 +106,46 @@ function getDocumento(instituicaoId) {
     });
 }
 
+function loadInstituicaoDocumentos(instituicaoId) {
+  resetAnoSelect('Selecione');
+  resetRelatorioSelect('Selecione');
+  document.getElementById('ano').disabled = true;
+  document.getElementById('relatorio').disabled = true;
+
+  if (instituicaoId != '') {
+    setSelectLoadingState('ano', 'Carregando anos');
+    getAnos(instituicaoId);
+  }
+}
+
 var instituicaoId = document.getElementById('ref_cod_instituicao').value;
 if (instituicaoId != '') {
-  setRelatorioLoadingState();
-  getDocumento(instituicaoId);
+  loadInstituicaoDocumentos(instituicaoId);
 }
 
 document.getElementById('btn_enviar').style.display = 'none';
 
 document.getElementById('ref_cod_instituicao').onchange = function () {
-  var selectRelatorio = document.getElementById('relatorio');
-
   if (this.selectedIndex !== 0) {
+    loadInstituicaoDocumentos(document.getElementById('ref_cod_instituicao').value);
+  } else {
+    resetAnoSelect('Selecione');
+    resetRelatorioSelect('Selecione');
+    document.getElementById('ano').disabled = true;
+    document.getElementById('relatorio').disabled = true;
+  }
+};
+
+document.getElementById('ano').onchange = function () {
+  var selectRelatorio = document.getElementById('relatorio');
+  var instituicaoId = document.getElementById('ref_cod_instituicao').value;
+
+  if (this.selectedIndex !== 0 && instituicaoId != '') {
     setRelatorioLoadingState();
-    getDocumento(document.getElementById('ref_cod_instituicao').value);
+    getDocumento(instituicaoId, this.value);
   } else {
     resetRelatorioSelect('Selecione');
+    selectRelatorio.disabled = true;
   }
 };
 

--- a/ieducar/intranet/styles/extra/DocumentacaoPadrao.css
+++ b/ieducar/intranet/styles/extra/DocumentacaoPadrao.css
@@ -1,3 +1,4 @@
-select#relatorio {
+select#relatorio,
+select#ano {
   min-width: 180px;
 }

--- a/ieducar/modules/Api/Views/InstituicaoDocumentacaoController.php
+++ b/ieducar/modules/Api/Views/InstituicaoDocumentacaoController.php
@@ -12,6 +12,7 @@ class InstituicaoDocumentacaoController extends ApiCoreController
             'url_documento' => request()->string('url_documento'),
             'ref_usuario_cad' => request()->integer('ref_usuario_cad'),
             'ref_cod_escola' => request()->integer('ref_cod_escola'),
+            'ano' => request()->integer('ano') ?: (int) date('Y'),
         ]);
 
         return [
@@ -22,6 +23,7 @@ class InstituicaoDocumentacaoController extends ApiCoreController
     protected function getDocuments()
     {
         $instituitionId = request()->integer('instituicao_id');
+        $year = request()->integer('ano');
 
         $documents = LegacyInstitutionDocument::query()
             ->select([
@@ -30,13 +32,30 @@ class InstituicaoDocumentacaoController extends ApiCoreController
                 'url_documento',
                 'ref_usuario_cad',
                 'ref_cod_escola',
+                'ano',
             ])
             ->where('instituicao_id', $instituitionId)
+            ->when($year, fn ($query) => $query->where('ano', $year))
+            ->orderByDesc('ano')
             ->orderByDesc('id')
             ->get()
             ->toArray();
 
         return ['documentos' => $documents];
+    }
+
+    protected function getYears()
+    {
+        $instituitionId = request()->integer('instituicao_id');
+
+        $years = LegacyInstitutionDocument::query()
+            ->where('instituicao_id', $instituitionId)
+            ->distinct()
+            ->orderByDesc('ano')
+            ->pluck('ano')
+            ->toArray();
+
+        return ['anos' => $years];
     }
 
     protected function deleteDocuments()
@@ -54,6 +73,8 @@ class InstituicaoDocumentacaoController extends ApiCoreController
             $this->appendResponse($this->insertDocuments());
         } elseif ($this->isRequestFor('get', 'getDocuments')) {
             $this->appendResponse($this->getDocuments());
+        } elseif ($this->isRequestFor('get', 'getYears')) {
+            $this->appendResponse($this->getYears());
         } elseif ($this->isRequestFor('get', 'deleteDocuments')) {
             $this->appendResponse($this->deleteDocuments());
         }

--- a/public/vendor/legacy/Cadastro/Assets/Javascripts/DocumentacaoPadrao.js
+++ b/public/vendor/legacy/Cadastro/Assets/Javascripts/DocumentacaoPadrao.js
@@ -1,156 +1,146 @@
 var $arrayDocumento = [];
 
 function inserirDocumento(url) {
-  var searchPath = '../module/Api/InstituicaoDocumentacao?oper=get&resource=insertDocuments';
+  var searchPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=insertDocuments';
   var ref_cod_escola;
-  if($j('#ref_cod_escola').val() == ''){
-    var ref_cod_escola = 'null';
-  }else{
-    var ref_cod_escola = $j('#ref_cod_escola').val();
+  if ($j('#ref_cod_escola').val() == '') {
+    ref_cod_escola = 'null';
+  } else {
+    ref_cod_escola = $j('#ref_cod_escola').val();
   }
-  var params = {instituicao_id : $j('#cod_instituicao').val(), titulo_documento : $j('#titulo_documento').val(), url_documento : url, ref_usuario_cad : $j('#pessoa_logada').val(), ref_cod_escola : ref_cod_escola}
-  console.log(params);
+  var params = {
+    instituicao_id: $j('#cod_instituicao').val(),
+    titulo_documento: $j('#titulo_documento').val(),
+    url_documento: url,
+    ref_usuario_cad: $j('#pessoa_logada').val(),
+    ref_cod_escola: ref_cod_escola,
+    ano: $j('#ano').val()
+  };
 
-  $j.get(searchPath, params, function(idDocumento){
-    addDocumento(idDocumento.id, $j('#titulo_documento').val(), url, "inline");
+  $j.get(searchPath, params, function (idDocumento) {
+    addDocumento(idDocumento.id, $j('#titulo_documento').val(), url, $j('#ano').val(), 'inline');
     $j('#titulo_documento').val('');
   });
 }
 
 function getDocumento() {
-var searchPath = '../module/Api/InstituicaoDocumentacao?oper=get&resource=getDocuments';
-  var params = {instituicao_id : $j('#cod_instituicao').val()}
-  var id     = '';
-  var titulo = '';
-  var url    = '';
+  var searchPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=getDocuments';
+  var params = { instituicao_id: $j('#cod_instituicao').val() };
 
-  $j.get(searchPath, params, function(data){
-
+  $j.get(searchPath, params, function (data) {
     var documentos = data.documentos;
     var escola = $j('#ref_cod_escola').val();
-    console.log(escola);
 
     for (var i = documentos.length - 1; i >= 0; i--) {
       if (escola == documentos[i].ref_cod_escola || escola == '') {
-        addDocumento(documentos[i].id, documentos[i].titulo_documento, documentos[i].url_documento, "inline");
-      }else{
-        addDocumento(documentos[i].id, documentos[i].titulo_documento, documentos[i].url_documento, "none");
+        addDocumento(documentos[i].id, documentos[i].titulo_documento, documentos[i].url_documento, documentos[i].ano, 'inline');
+      } else {
+        addDocumento(documentos[i].id, documentos[i].titulo_documento, documentos[i].url_documento, documentos[i].ano, 'none');
       }
     }
   });
 }
 
-function excluirDocumento(event){
-  var searchPath = '../module/Api/InstituicaoDocumentacao?oper=get&resource=deleteDocuments';
-  var params = {id : event.data['id']}
-  if(confirm("Deseja realmente excluir este documento?")){
-    $j.get(searchPath, params, function(deleteID){
-      $j('#'+event.data['id']).hide();
+function excluirDocumento(event) {
+  var searchPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=deleteDocuments';
+  var params = { id: event.data['id'] };
+  if (confirm('Deseja realmente excluir este documento?')) {
+    $j.get(searchPath, params, function () {
+      $j('#' + event.data['id']).hide();
     });
   }
 }
 
 getDocumento();
 
-function addDocumento(id, titulo, url, display){
-  console.log(display);
-  $arrayDocumento[$arrayDocumento.length] = $j('<div>').attr('id', id).append($j('<div>').html(stringUtils.toUtf8(titulo + ':'))
-                                                                          .css({ "text-align" : "right", "float" : "left"}))
-                                                                          .append($j('<span>').append($j('<a>').html(stringUtils.toUtf8('Excluir'))
-                                                                                           .addClass('decorated')
-                                                                                           .attr('id','link_excluir_documento_'+id)
-                                                                                           .css({ "cursor": "pointer", "color" : "#B22222", "display" : display})
-                                                                                           .css('margin-left','10px')
-                                                                                           .click({id: id}, excluirDocumento)))
-                                                                          .append($j('<span>').append($j('<a>').html(stringUtils.toUtf8('Visualizar'))
-                                                                                           .addClass('decorated')
-                                                                                           .attr('id','link_visualizar_documento_'+id)
-                                                                                           .attr('target','_blank')
-                                                                                           .attr('href',linkUrlPrivada(url))
-                                                                                           .css({ "cursor": "pointer", "color" : "#556B2F"})
-                                                                                           .css('margin-left','10px')))
-                                                                          .insertAfter($j('#aviso_formato'));
-
+function addDocumento(id, titulo, url, ano, display) {
+  var label = titulo + ' (' + ano + '):';
+  $arrayDocumento[$arrayDocumento.length] = $j('<div>').attr('id', id).append($j('<div>').html(stringUtils.toUtf8(label))
+    .css({ 'text-align': 'right', 'float': 'left' }))
+    .append($j('<span>').append($j('<a>').html(stringUtils.toUtf8('Excluir'))
+      .addClass('decorated')
+      .attr('id', 'link_excluir_documento_' + id)
+      .css({ 'cursor': 'pointer', 'color': '#B22222', 'display': display })
+      .css('margin-left', '10px')
+      .click({ id: id }, excluirDocumento)))
+    .append($j('<span>').append($j('<a>').html(stringUtils.toUtf8('Visualizar'))
+      .addClass('decorated')
+      .attr('id', 'link_visualizar_documento_' + id)
+      .attr('target', '_blank')
+      .attr('href', linkUrlPrivada(url))
+      .css({ 'cursor': 'pointer', 'color': '#556B2F' })
+      .css('margin-left', '10px')))
+    .insertAfter($j('#aviso_formato'));
 }
 
-var $loadingDocumento =  $j('<img>').attr('src', 'imagens/indicator.gif')
-                                      .css('margin-top', '3px')
-                                      .hide()
-                                      .insertAfter($j('#aviso_formato'));
+var $loadingDocumento = $j('<img>').attr('src', 'imagens/indicator.gif')
+  .css('margin-top', '3px')
+  .hide()
+  .insertAfter($j('#aviso_formato'));
 
-// when page is ready
-
-(function($) {
-  $(document).ready(function() {
-
+(function ($) {
+  $(document).ready(function () {
     $('#btn_enviar').hide();
 
-    var titulo = $j('#titulo_documento').val();
     $j('#documento').on('change', prepareUploadDocumento);
 
-    function prepareUploadDocumento(event)
-    {
+    function prepareUploadDocumento(event) {
       $j('#documento').removeClass('error');
       uploadFilesDocumento(event.target.files);
     }
 
+    function uploadFilesDocumento(files) {
+      if ($j('#ano').val() === '') {
+        alert('Favor, inserir o ano deste documento.');
+        $j('#documento').val('').clone(true);
+        return;
+      }
 
-    function uploadFilesDocumento(files)
-    {
-      if ($j('#titulo_documento').val() !== '' ){
-        if (files && files.length>0){
+      if ($j('#titulo_documento').val() !== '') {
+        if (files && files.length > 0) {
           $j('#documento').attr('disabled', 'disabled');
           $j('#btn_enviar').attr('disabled', 'disabled').val('Aguarde...');
           $loadingDocumento.show();
           messageUtils.notice('Carregando documento...');
 
           var data = new FormData();
-          $j.each(files, function(key, value)
-          {
+          $j.each(files, function (key, value) {
             data.append(key, value);
           });
 
           $j.ajax({
-              url: '/intranet/upload_just_pdf.php?files',
-              type: 'POST',
-              data: data,
-              cache: false,
-              dataType: 'json',
-              processData: false,
-              contentType: false,
-              success: function(dataResponse)
-              {
-                if (dataResponse.error){
-                  $j('#documento').val("").addClass('error');
-                  messageUtils.error(dataResponse.error);
-                }else{
-                  messageUtils.success('Documento carregado com sucesso');
-                  $j('#documento').addClass('success');
-                  inserirDocumento(dataResponse.file_url);
-                }
-
-              },
-              error: function()
-              {
-                $j('#documento').val("").addClass('error');
-                messageUtils.error('Não foi possível enviar o arquivo');
-              },
-              complete: function()
-              {
-                $j('#documento').removeAttr('disabled');
-                $loadingDocumento.hide();
-                $j('#btn_enviar').removeAttr('disabled').val('Gravar');
+            url: '/intranet/upload_just_pdf.php?files',
+            type: 'POST',
+            data: data,
+            cache: false,
+            dataType: 'json',
+            processData: false,
+            contentType: false,
+            success: function (dataResponse) {
+              if (dataResponse.error) {
+                $j('#documento').val('').addClass('error');
+                messageUtils.error(dataResponse.error);
+              } else {
+                messageUtils.success('Documento carregado com sucesso');
+                $j('#documento').addClass('success');
+                inserirDocumento(dataResponse.file_url);
               }
+            },
+            error: function () {
+              $j('#documento').val('').addClass('error');
+              messageUtils.error('Não foi possível enviar o arquivo');
+            },
+            complete: function () {
+              $j('#documento').removeAttr('disabled');
+              $loadingDocumento.hide();
+              $j('#btn_enviar').removeAttr('disabled').val('Gravar');
+            }
           });
         }
-      }else{
+      } else {
         alert('Favor, inserir um t\u00edtulo para este documento.');
         $j('#documento').val('').clone(true);
       }
     }
-
-
-  }); // ready
-
-  //gambiarra sinistra que funciona
+  });
 })(jQuery);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**DESCRIÇÃO:**

Corrige o problema em `/intranet/DocumentacaoPadrao.php` em que o campo **Relatório*** ficava preso na mensagem "Carregando relatórios" após selecionar uma instituição.

Adiciona suporte a **ano** na documentação padrão:

- Migration com coluna `ano` em `pmieducar.instituicao_documentacao` (documentos existentes recebem o ano atual)
- Campo **Ano** no cadastro (Instituição → Documentação padrão)
- Filtro em cascata na consulta: **Instituição → Ano → Relatório**
- Novo endpoint API `getYears` para listar anos disponíveis por instituição

Alterações adicionais:
- Tratamento de lista vazia, erro de API e falha de rede
- Caminho absoluto para chamadas AJAX da API
- Evita campo duplicado de instituição para usuários de nível 4

**AMBIENTE:**

- Cloud Agent / Linux
- Branch base: `2.11`

**MIGRAÇÃO:**

Após o deploy, executar:

```bash
php artisan migrate
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbf5aa21-4c19-4a35-acd3-efd1db9d173b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbf5aa21-4c19-4a35-acd3-efd1db9d173b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

