### PR TITLE
Corrige carregamento dos anos letivos na Documentação padrão

### DIFF
--- a/ieducar/intranet/DocumentacaoPadrao.php
+++ b/ieducar/intranet/DocumentacaoPadrao.php
@@ -62,7 +62,7 @@ return new class extends clsCadastro
 
         $opcoes_ano = [];
         $opcoes_ano[''] = 'Selecione';
-        $this->campoLista('ano', 'Ano', $opcoes_ano);
+        $this->campoLista('ano', 'Ano letivo', $opcoes_ano);
 
         $opcoes_relatorio = [];
         $opcoes_relatorio[''] = 'Selecione';

--- a/ieducar/intranet/scripts/extra/DocumentacaoPadrao.js
+++ b/ieducar/intranet/scripts/extra/DocumentacaoPadrao.js
@@ -3,6 +3,10 @@ var yearsPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=getYears'
 
 function setSelectLoadingState(selectId, message) {
   var select = document.getElementById(selectId);
+  if (!select) {
+    return;
+  }
+
   select.length = 1;
   select.disabled = true;
   select.options[0].text = message;
@@ -10,6 +14,10 @@ function setSelectLoadingState(selectId, message) {
 
 function resetSelect(selectId, message, disabled) {
   var select = document.getElementById(selectId);
+  if (!select) {
+    return;
+  }
+
   select.length = 1;
   select.options[0].text = message;
   select.disabled = disabled;
@@ -29,6 +37,10 @@ function resetAnoSelect(message) {
 
 function populateAnoSelect(anos) {
   var selectAno = document.getElementById('ano');
+  if (!selectAno) {
+    return;
+  }
+
   selectAno.length = 1;
 
   if (!anos || !anos.length) {
@@ -52,6 +64,10 @@ function populateAnoSelect(anos) {
 
 function populateRelatorioSelect(documentos) {
   var selectRelatorio = document.getElementById('relatorio');
+  if (!selectRelatorio) {
+    return;
+  }
+
   selectRelatorio.length = 1;
 
   if (!documentos || !documentos.length) {
@@ -109,48 +125,70 @@ function getDocumento(instituicaoId, ano) {
 function loadInstituicaoDocumentos(instituicaoId) {
   resetAnoSelect('Selecione');
   resetRelatorioSelect('Selecione');
-  document.getElementById('ano').disabled = true;
-  document.getElementById('relatorio').disabled = true;
+
+  var selectAno = document.getElementById('ano');
+  var selectRelatorio = document.getElementById('relatorio');
+
+  if (selectAno) {
+    selectAno.disabled = true;
+  }
+
+  if (selectRelatorio) {
+    selectRelatorio.disabled = true;
+  }
 
   if (instituicaoId != '') {
-    setSelectLoadingState('ano', 'Carregando anos');
+    setSelectLoadingState('ano', 'Carregando anos letivos');
     getAnos(instituicaoId);
   }
 }
 
-var instituicaoId = document.getElementById('ref_cod_instituicao').value;
-if (instituicaoId != '') {
-  loadInstituicaoDocumentos(instituicaoId);
-}
+$j(function () {
+  var $instituicao = $j('#ref_cod_instituicao');
+  var $ano = $j('#ano');
+  var $relatorio = $j('#relatorio');
+  var $btnEnviar = $j('#btn_enviar');
 
-document.getElementById('btn_enviar').style.display = 'none';
+  if (!$instituicao.length || !$ano.length || !$relatorio.length) {
+    return;
+  }
 
-document.getElementById('ref_cod_instituicao').onchange = function () {
-  if (this.selectedIndex !== 0) {
-    loadInstituicaoDocumentos(document.getElementById('ref_cod_instituicao').value);
-  } else {
-    resetAnoSelect('Selecione');
+  if ($btnEnviar.length) {
+    $btnEnviar.hide();
+  }
+
+  $instituicao.on('change', function () {
+    if (this.selectedIndex !== undefined && this.selectedIndex === 0) {
+      resetAnoSelect('Selecione');
+      resetRelatorioSelect('Selecione');
+      $ano.prop('disabled', true);
+      $relatorio.prop('disabled', true);
+      return;
+    }
+
+    loadInstituicaoDocumentos($instituicao.val());
+  });
+
+  $ano.on('change', function () {
+    var instituicaoId = $instituicao.val();
+
+    if (this.selectedIndex !== 0 && instituicaoId != '') {
+      setRelatorioLoadingState();
+      getDocumento(instituicaoId, this.value);
+      return;
+    }
+
     resetRelatorioSelect('Selecione');
-    document.getElementById('ano').disabled = true;
-    document.getElementById('relatorio').disabled = true;
-  }
-};
+    $relatorio.prop('disabled', true);
+  });
 
-document.getElementById('ano').onchange = function () {
-  var selectRelatorio = document.getElementById('relatorio');
-  var instituicaoId = document.getElementById('ref_cod_instituicao').value;
+  $relatorio.on('change', function () {
+    if (this.selectedIndex !== 0) {
+      window.open(linkUrlPrivada(this.value), '_blank');
+    }
+  });
 
-  if (this.selectedIndex !== 0 && instituicaoId != '') {
-    setRelatorioLoadingState();
-    getDocumento(instituicaoId, this.value);
-  } else {
-    resetRelatorioSelect('Selecione');
-    selectRelatorio.disabled = true;
+  if ($instituicao.val() != '') {
+    loadInstituicaoDocumentos($instituicao.val());
   }
-};
-
-document.getElementById('relatorio').onchange = function () {
-  if (this.selectedIndex !== 0) {
-    window.open(linkUrlPrivada(this.value), '_blank');
-  }
-};
+});

--- a/ieducar/modules/Api/Views/InstituicaoDocumentacaoController.php
+++ b/ieducar/modules/Api/Views/InstituicaoDocumentacaoController.php
@@ -48,8 +48,14 @@ class InstituicaoDocumentacaoController extends ApiCoreController
     {
         $instituitionId = request()->integer('instituicao_id');
 
+        if (!$instituitionId) {
+            return ['anos' => []];
+        }
+
         $years = LegacyInstitutionDocument::query()
             ->where('instituicao_id', $instituitionId)
+            ->whereNotNull('ano')
+            ->select('ano')
             ->distinct()
             ->orderByDesc('ano')
             ->pluck('ano')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

Na tela `/intranet/DocumentacaoPadrao.php`, o select de anos letivos não era populado após selecionar (ou auto-selecionar) a instituição.

## Causa

O JavaScript inline era executado imediatamente e apresentava dois problemas:

1. **Erro silencioso em `btn_enviar`**: se o botão não existisse, o script quebrava antes de registrar o handler `change` da instituição.
2. **Condição de corrida com o DynamicInput**: quando havia apenas uma instituição, o `DynamicInput.js` auto-selecionava o valor após ~200ms, mas o handler ainda não estava registrado — os anos nunca eram carregados.

## Solução

- Inicialização dentro de `$j(function() { ... })` (document ready)
- Handlers registrados via jQuery `.on('change')`
- Verificações de existência dos elementos DOM antes de manipulá-los
- Consulta `getYears` na API com `select('ano')->distinct()` e validação de `instituicao_id`
- Label do campo atualizado para "Ano letivo"

## Arquivos alterados

- `ieducar/intranet/scripts/extra/DocumentacaoPadrao.js`
- `ieducar/modules/Api/Views/InstituicaoDocumentacaoController.php`
- `ieducar/intranet/DocumentacaoPadrao.php`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3decaff-2f75-46a2-b768-3a5300a8425c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3decaff-2f75-46a2-b768-3a5300a8425c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

