### PR TITLE
Permite upload de DOCX na documentação da instituição

### DIFF
--- a/ieducar/intranet/educar_documentacao_instituicao_cad.php
+++ b/ieducar/intranet/educar_documentacao_instituicao_cad.php
@@ -42,7 +42,7 @@ return new class extends clsCadastro
 
         $this->campoTexto(nome: 'titulo_documento', campo: 'Título', valor: $this->titulo_documento, tamanhovisivel: 30, tamanhomaximo: 50);
 
-        $this->campoArquivo(nome: 'documento', campo: 'Documentação padrão', valor: $this->documento, tamanho: 40, descricao: '<span id=\'aviso_formato\'>São aceitos apenas arquivos no formato PDF com até 2MB.</span>');
+        $this->campoArquivo(nome: 'documento', campo: 'Documentação padrão', valor: $this->documento, tamanho: 40, descricao: '<span id=\'aviso_formato\'>São aceitos arquivos nos formatos PDF e DOCX com até 2MB.</span>');
 
         $this->array_botao[] = 'Salvar';
         $this->array_botao_url_script[] = 'go(\'educar_instituicao_lst.php\')';

--- a/ieducar/intranet/include/file_check_just_pdf.php
+++ b/ieducar/intranet/include/file_check_just_pdf.php
@@ -27,9 +27,9 @@ class FileControllerPdf
         }
 
         if ($suportedExtensions != null) {
-            $this->suportedExtensions = $suportedExtensions;
+            $this->suportedExtensions = array_map('strtolower', $suportedExtensions);
         } else {
-            $this->suportedExtensions = ['pdf'];
+            $this->suportedExtensions = ['pdf', 'docx'];
         }
     }
 
@@ -54,21 +54,21 @@ class FileControllerPdf
     {
         $name = $this->file['name'];
         $size = $this->file['size'];
-        $ext = $this->getExtension($name);
+        $ext = strtolower($this->getExtension($name));
 
         if (strlen($name) > 0) {
             // File format validation
-            if (in_array($ext, $this->suportedExtensions)) {
+            if (in_array($ext, $this->suportedExtensions, true)) {
                 // File size validation
                 if ($size < $this->maxSize) {
                     return true;
                 } else {
-                    $this->errorMessage = 'não são permitidos arquivos com mais de 2MB.';
+                    $this->errorMessage = 'Não são permitidos arquivos com mais de 2MB.';
 
                     return false;
                 }
             } else {
-                $this->errorMessage = 'Deve ser enviado um arquivo do tipo pdf.';
+                $this->errorMessage = 'Deve ser enviado um arquivo do tipo ' . implode(', ', $this->suportedExtensions) . '.';
 
                 return false;
             }

--- a/ieducar/intranet/upload_just_pdf.php
+++ b/ieducar/intranet/upload_just_pdf.php
@@ -3,7 +3,7 @@
 if ($_FILES) {
     foreach ($_FILES as $file) {
         if (!empty($file['name'])) {
-            $objFile = new FileControllerPdf($file);
+            $objFile = new FileControllerPdf($file, 2 * 1024 * 1024, ['pdf', 'docx']);
             if ($objFile->validateFile()) {
                 $caminho = $objFile->sendFile();
                 if ($caminho != '') {

--- a/public/vendor/legacy/Cadastro/Assets/Javascripts/DocumentacaoPadrao.js
+++ b/public/vendor/legacy/Cadastro/Assets/Javascripts/DocumentacaoPadrao.js
@@ -79,8 +79,22 @@ var $loadingDocumento = $j('<img>').attr('src', 'imagens/indicator.gif')
   .insertAfter($j('#aviso_formato'));
 
 (function ($) {
+  var allowedExtensions = ['pdf', 'docx'];
+  var maxFileSize = 2 * 1024 * 1024;
+
+  function isAllowedDocumentFile(file) {
+    if (!file || !file.name) {
+      return false;
+    }
+
+    var extension = file.name.split('.').pop().toLowerCase();
+
+    return allowedExtensions.indexOf(extension) !== -1;
+  }
+
   $(document).ready(function () {
     $('#btn_enviar').hide();
+    $j('#documento').attr('accept', '.pdf,.docx,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document');
 
     $j('#documento').on('change', prepareUploadDocumento);
 
@@ -98,6 +112,18 @@ var $loadingDocumento = $j('<img>').attr('src', 'imagens/indicator.gif')
 
       if ($j('#titulo_documento').val() !== '') {
         if (files && files.length > 0) {
+          if (!isAllowedDocumentFile(files[0])) {
+            messageUtils.error('Deve ser enviado um arquivo do tipo pdf, docx.');
+            $j('#documento').val('').addClass('error');
+            return;
+          }
+
+          if (files[0].size >= maxFileSize) {
+            messageUtils.error('Não são permitidos arquivos com mais de 2MB.');
+            $j('#documento').val('').addClass('error');
+            return;
+          }
+
           $j('#documento').attr('disabled', 'disabled');
           $j('#btn_enviar').attr('disabled', 'disabled').val('Aguarde...');
           $loadingDocumento.show();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objetivo

Permitir o upload de arquivos **DOCX** na tela de cadastro de documentação da instituição (`/intranet/educar_documentacao_instituicao_cad.php`).

## Alterações

- Backend (`upload_just_pdf.php` / `FileControllerPdf`): aceita **PDF** e **DOCX**, com limite de **2MB**
- Mensagem da tela de cadastro atualizada para refletir os formatos aceitos
- Validação no frontend antes do envio (extensão e tamanho)
- Atributo `accept` no input de arquivo para facilitar a seleção no navegador

## Arquivos alterados

- `ieducar/intranet/include/file_check_just_pdf.php`
- `ieducar/intranet/upload_just_pdf.php`
- `ieducar/intranet/educar_documentacao_instituicao_cad.php`
- `public/vendor/legacy/Cadastro/Assets/Javascripts/DocumentacaoPadrao.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3decaff-2f75-46a2-b768-3a5300a8425c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3decaff-2f75-46a2-b768-3a5300a8425c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

