### PR TITLE
Corrige conflito de resetSelect na Documentação padrão

### DIFF
--- a/ieducar/intranet/scripts/extra/DocumentacaoPadrao.js
+++ b/ieducar/intranet/scripts/extra/DocumentacaoPadrao.js
@@ -1,194 +1,196 @@
-var searchPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=getDocuments';
-var yearsPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=getYears';
+(function () {
+  var searchPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=getDocuments';
+  var yearsPath = '/module/Api/InstituicaoDocumentacao?oper=get&resource=getYears';
 
-function setSelectLoadingState(selectId, message) {
-  var select = document.getElementById(selectId);
-  if (!select) {
-    return;
+  function setSelectLoadingState(selectId, message) {
+    var select = document.getElementById(selectId);
+    if (!select) {
+      return;
+    }
+
+    select.length = 1;
+    select.disabled = true;
+    select.options[0].text = message;
   }
 
-  select.length = 1;
-  select.disabled = true;
-  select.options[0].text = message;
-}
+  function resetDocumentacaoSelect(selectId, message, disabled) {
+    var select = document.getElementById(selectId);
+    if (!select) {
+      return;
+    }
 
-function resetSelect(selectId, message, disabled) {
-  var select = document.getElementById(selectId);
-  if (!select) {
-    return;
+    select.length = 1;
+    select.options[0].text = message;
+    select.disabled = disabled;
   }
 
-  select.length = 1;
-  select.options[0].text = message;
-  select.disabled = disabled;
-}
-
-function setRelatorioLoadingState() {
-  setSelectLoadingState('relatorio', 'Carregando relatórios');
-}
-
-function resetRelatorioSelect(message) {
-  resetSelect('relatorio', message, false);
-}
-
-function resetAnoSelect(message) {
-  resetSelect('ano', message, false);
-}
-
-function populateAnoSelect(anos) {
-  var selectAno = document.getElementById('ano');
-  if (!selectAno) {
-    return;
+  function setRelatorioLoadingState() {
+    setSelectLoadingState('relatorio', 'Carregando relatórios');
   }
 
-  selectAno.length = 1;
+  function resetRelatorioSelect(message) {
+    resetDocumentacaoSelect('relatorio', message, false);
+  }
 
-  if (!anos || !anos.length) {
-    resetAnoSelect('A instituição não possui documentos cadastrados');
+  function resetAnoSelect(message) {
+    resetDocumentacaoSelect('ano', message, false);
+  }
+
+  function populateAnoSelect(anos) {
+    var selectAno = document.getElementById('ano');
+    if (!selectAno) {
+      return;
+    }
+
+    selectAno.length = 1;
+
+    if (!anos || !anos.length) {
+      resetAnoSelect('A instituição não possui documentos cadastrados');
+      resetRelatorioSelect('Selecione');
+      return;
+    }
+
+    selectAno.options[0].text = 'Selecione um ano';
+    selectAno.disabled = false;
+
+    for (var i = 0; i < anos.length; i++) {
+      var option = document.createElement('option');
+      option.text = anos[i];
+      option.value = anos[i];
+      selectAno.add(option);
+    }
+
     resetRelatorioSelect('Selecione');
-    return;
   }
 
-  selectAno.options[0].text = 'Selecione um ano';
-  selectAno.disabled = false;
+  function populateRelatorioSelect(documentos) {
+    var selectRelatorio = document.getElementById('relatorio');
+    if (!selectRelatorio) {
+      return;
+    }
 
-  for (var i = 0; i < anos.length; i++) {
-    var option = document.createElement('option');
-    option.text = anos[i];
-    option.value = anos[i];
-    selectAno.add(option);
+    selectRelatorio.length = 1;
+
+    if (!documentos || !documentos.length) {
+      resetRelatorioSelect('Não há relatórios para o ano selecionado');
+      return;
+    }
+
+    selectRelatorio.options[0].text = 'Selecione um relatório';
+    selectRelatorio.disabled = false;
+
+    for (var i = 0; i < documentos.length; i++) {
+      var option = document.createElement('option');
+      option.text = documentos[i].titulo_documento;
+      option.value = documentos[i].url_documento;
+      selectRelatorio.add(option);
+    }
   }
 
-  resetRelatorioSelect('Selecione');
-}
+  function getAnos(instituicaoId) {
+    var params = { instituicao_id: instituicaoId };
 
-function populateRelatorioSelect(documentos) {
-  var selectRelatorio = document.getElementById('relatorio');
-  if (!selectRelatorio) {
-    return;
-  }
+    $j.get(yearsPath, params)
+      .done(function (data) {
+        if (data && data.any_error_msg) {
+          resetAnoSelect('Não foi possível carregar os anos');
+          resetRelatorioSelect('Selecione');
+          return;
+        }
 
-  selectRelatorio.length = 1;
-
-  if (!documentos || !documentos.length) {
-    resetRelatorioSelect('Não há relatórios para o ano selecionado');
-    return;
-  }
-
-  selectRelatorio.options[0].text = 'Selecione um relatório';
-  selectRelatorio.disabled = false;
-
-  for (var i = 0; i < documentos.length; i++) {
-    var option = document.createElement('option');
-    option.text = documentos[i].titulo_documento;
-    option.value = documentos[i].url_documento;
-    selectRelatorio.add(option);
-  }
-}
-
-function getAnos(instituicaoId) {
-  var params = { instituicao_id: instituicaoId };
-
-  $j.get(yearsPath, params)
-    .done(function (data) {
-      if (data && data.any_error_msg) {
+        populateAnoSelect(data ? data.anos : []);
+      })
+      .fail(function () {
         resetAnoSelect('Não foi possível carregar os anos');
         resetRelatorioSelect('Selecione');
-        return;
-      }
+      });
+  }
 
-      populateAnoSelect(data ? data.anos : []);
-    })
-    .fail(function () {
-      resetAnoSelect('Não foi possível carregar os anos');
-      resetRelatorioSelect('Selecione');
-    });
-}
+  function getDocumento(instituicaoId, ano) {
+    var params = { instituicao_id: instituicaoId, ano: ano };
 
-function getDocumento(instituicaoId, ano) {
-  var params = { instituicao_id: instituicaoId, ano: ano };
+    $j.get(searchPath, params)
+      .done(function (data) {
+        if (data && data.any_error_msg) {
+          resetRelatorioSelect('Não foi possível carregar os relatórios');
+          return;
+        }
 
-  $j.get(searchPath, params)
-    .done(function (data) {
-      if (data && data.any_error_msg) {
+        populateRelatorioSelect(data ? data.documentos : []);
+      })
+      .fail(function () {
         resetRelatorioSelect('Não foi possível carregar os relatórios');
+      });
+  }
+
+  function loadInstituicaoDocumentos(instituicaoId) {
+    resetAnoSelect('Selecione');
+    resetRelatorioSelect('Selecione');
+
+    var selectAno = document.getElementById('ano');
+    var selectRelatorio = document.getElementById('relatorio');
+
+    if (selectAno) {
+      selectAno.disabled = true;
+    }
+
+    if (selectRelatorio) {
+      selectRelatorio.disabled = true;
+    }
+
+    if (instituicaoId != '') {
+      setSelectLoadingState('ano', 'Carregando anos letivos');
+      getAnos(instituicaoId);
+    }
+  }
+
+  $j(function () {
+    var $instituicao = $j('#ref_cod_instituicao');
+    var $ano = $j('#ano');
+    var $relatorio = $j('#relatorio');
+    var $btnEnviar = $j('#btn_enviar');
+
+    if (!$instituicao.length || !$ano.length || !$relatorio.length) {
+      return;
+    }
+
+    if ($btnEnviar.length) {
+      $btnEnviar.hide();
+    }
+
+    $instituicao.on('change', function () {
+      if (this.selectedIndex !== undefined && this.selectedIndex === 0) {
+        resetAnoSelect('Selecione');
+        resetRelatorioSelect('Selecione');
+        $ano.prop('disabled', true);
+        $relatorio.prop('disabled', true);
         return;
       }
 
-      populateRelatorioSelect(data ? data.documentos : []);
-    })
-    .fail(function () {
-      resetRelatorioSelect('Não foi possível carregar os relatórios');
+      loadInstituicaoDocumentos($instituicao.val());
     });
-}
 
-function loadInstituicaoDocumentos(instituicaoId) {
-  resetAnoSelect('Selecione');
-  resetRelatorioSelect('Selecione');
+    $ano.on('change', function () {
+      var instituicaoId = $instituicao.val();
 
-  var selectAno = document.getElementById('ano');
-  var selectRelatorio = document.getElementById('relatorio');
+      if (this.selectedIndex !== 0 && instituicaoId != '') {
+        setRelatorioLoadingState();
+        getDocumento(instituicaoId, this.value);
+        return;
+      }
 
-  if (selectAno) {
-    selectAno.disabled = true;
-  }
-
-  if (selectRelatorio) {
-    selectRelatorio.disabled = true;
-  }
-
-  if (instituicaoId != '') {
-    setSelectLoadingState('ano', 'Carregando anos letivos');
-    getAnos(instituicaoId);
-  }
-}
-
-$j(function () {
-  var $instituicao = $j('#ref_cod_instituicao');
-  var $ano = $j('#ano');
-  var $relatorio = $j('#relatorio');
-  var $btnEnviar = $j('#btn_enviar');
-
-  if (!$instituicao.length || !$ano.length || !$relatorio.length) {
-    return;
-  }
-
-  if ($btnEnviar.length) {
-    $btnEnviar.hide();
-  }
-
-  $instituicao.on('change', function () {
-    if (this.selectedIndex !== undefined && this.selectedIndex === 0) {
-      resetAnoSelect('Selecione');
       resetRelatorioSelect('Selecione');
-      $ano.prop('disabled', true);
       $relatorio.prop('disabled', true);
-      return;
-    }
+    });
 
-    loadInstituicaoDocumentos($instituicao.val());
-  });
+    $relatorio.on('change', function () {
+      if (this.selectedIndex !== 0) {
+        window.open(linkUrlPrivada(this.value), '_blank');
+      }
+    });
 
-  $ano.on('change', function () {
-    var instituicaoId = $instituicao.val();
-
-    if (this.selectedIndex !== 0 && instituicaoId != '') {
-      setRelatorioLoadingState();
-      getDocumento(instituicaoId, this.value);
-      return;
-    }
-
-    resetRelatorioSelect('Selecione');
-    $relatorio.prop('disabled', true);
-  });
-
-  $relatorio.on('change', function () {
-    if (this.selectedIndex !== 0) {
-      window.open(linkUrlPrivada(this.value), '_blank');
+    if ($instituicao.val() != '') {
+      loadInstituicaoDocumentos($instituicao.val());
     }
   });
-
-  if ($instituicao.val() != '') {
-    loadInstituicaoDocumentos($instituicao.val());
-  }
-});
+})();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

Ao abrir `/intranet/DocumentacaoPadrao.php`, o console exibia:

```
Uncaught TypeError: $targetElement.children is not a function
    at resetSelect (DynamicInput.js:44:18)
    at resetAnoSelect (DocumentacaoPadrao.php:...)
```

## Causa

O script da Documentação padrão declarava uma função global `resetSelect(selectId, message, disabled)`, com a mesma assinatura/nome da função `resetSelect($targetElement)` do `DynamicInput.js` (carregado pelo campo dinâmico de instituição).

Quando o `DynamicInput.js` era carregado depois, ele sobrescrevia a função global. As chamadas internas passavam uma string (`'ano'`) em vez de um objeto jQuery, gerando o erro.

## Solução

- Encapsular todo o script em um IIFE (escopo privado)
- Renomear a função interna para `resetDocumentacaoSelect`

## Arquivo alterado

- `ieducar/intranet/scripts/extra/DocumentacaoPadrao.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3decaff-2f75-46a2-b768-3a5300a8425c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3decaff-2f75-46a2-b768-3a5300a8425c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

